### PR TITLE
Fix: Unity3d wont save UnityDragonBonesData, if it is created via context menu

### DIFF
--- a/Unity/src/DragonBones/unity/Editor/UnityEditor.cs
+++ b/Unity/src/DragonBones/unity/Editor/UnityEditor.cs
@@ -297,6 +297,9 @@ namespace DragonBones
 				if(textureAtlas!=null && textureAtlas.Length>0 && textureAtlas[0]!=null && textureAtlas[0].texture!=null){
 					data.textureAtlas = textureAtlas;
 				}
+        
+        AssetDatabase.Refresh ();
+				EditorUtility.SetDirty (data);
 				AssetDatabase.SaveAssets();
 				return data;
 			}

--- a/Unity/src/DragonBones/unity/Editor/UnityEditor.cs
+++ b/Unity/src/DragonBones/unity/Editor/UnityEditor.cs
@@ -298,7 +298,7 @@ namespace DragonBones
 					data.textureAtlas = textureAtlas;
 				}
         
-        AssetDatabase.Refresh ();
+        			AssetDatabase.Refresh ();
 				EditorUtility.SetDirty (data);
 				AssetDatabase.SaveAssets();
 				return data;


### PR DESCRIPTION
Small hotfix for an issue I found today

How to reproduce:
1). Select .json in Assets folder
2). Click RMB and select Creae>DragonBones>Create Unity Data
3). Restart Unity3d
4).  UnityDragonBonesData created at step 2 will be empty

Details
http://answers.unity3d.com/questions/927689/scriptableobject-asset-not-saved-to-disk.html
