### PR TITLE
Load non GUI texture when loading GUI texture

### DIFF
--- a/Unity/src/DragonBones/Scripts/unity/UnityFactory.cs
+++ b/Unity/src/DragonBones/Scripts/unity/UnityFactory.cs
@@ -762,6 +762,10 @@ namespace DragonBones
                     textureAtlasData.imagePath = UnityFactoryHelper.GetTextureAtlasImagePath(textureAtlasJSONPath, textureAtlasData.imagePath);
 
                     _RefreshTextureAtlas(textureAtlasData, isUGUI);
+                    if (isUGUI)
+                    {
+                        _RefreshTextureAtlas(textureAtlasData, false);
+                    }
                 }
 
                 return textureAtlasData;


### PR DESCRIPTION
Hi to all 🎉,

I was having trouble with loading assets from code in GUI mode. I don't know if I'm loading the data in a wrong way, but I just wanted to expose how I solved my problem.

The problem was that If I load the data like this:
```
            UnityFactory.factory.LoadDragonBonesData("path/to/name_ske");
            UnityFactory.factory.LoadTextureAtlasData("path/to/name_tex", isUGUI: true);

            UnityFactory.factory.BuildArmatureComponent("armatureName", isUGUI: true);
```

The loading process crashes here https://github.com/DragonBones/DragonBonesCSharp/blob/11bf7b74174a0cfc1dc71be138bba645d0a01ad2/Unity/Demos/Assets/DragonBones/Scripts/unity/UnityTextureAtlasData.cs#L171 because my DragonBones data had some slots with blending mode different than `BlendModel.Normal`, which causes the method `_GetUIMaterial` to search for the `texture`instead of the `uiTexture` which is not loaded.

So, when loading the UI texture, I think that we should also load the normal texture.

Let me know if I'm loading the data in a wrong way or this is a current bug.

Thanks a lot!