### PR TITLE
add CustomMaterialOverride

### DIFF
--- a/DragonBones/src/DragonBones/armature/Armature.cs
+++ b/DragonBones/src/DragonBones/armature/Armature.cs
@@ -967,12 +967,7 @@ namespace DragonBones
                 }
 
                 this._replacedTexture = value;
-
-                foreach (var slot in this._slots)
-                {
-                    slot.InvalidUpdate();
-                    slot.Update(-1);
-                }
+                UpdateSlots();
             }
         }
         /// <inheritDoc/>
@@ -1025,6 +1020,15 @@ namespace DragonBones
         public Slot parent
         {
             get { return this._parent; }
+        }
+
+        internal void UpdateSlots()
+        {
+            foreach (var slot in this._slots)
+            {
+                slot.InvalidUpdate();
+                slot.Update(-1);
+            }
         }
     }
 }

--- a/Unity/src/DragonBones/Scripts/unity/UnityArmatureComponent.cs
+++ b/Unity/src/DragonBones/Scripts/unity/UnityArmatureComponent.cs
@@ -99,6 +99,9 @@ namespace DragonBones
         private bool _disposeProxy = true;
         /// <private/>
         internal Armature _armature = null;
+        private Dictionary<Material, Material> _customMaterialOverride;
+        public Dictionary<Material, Material> CustomMaterialOverride => _customMaterialOverride;
+
         [Tooltip("0 : Loop")]
         [Range(0, 100)]
         [SerializeField]
@@ -667,6 +670,7 @@ namespace DragonBones
         /// <private/>
         void Awake()
         {
+            _customMaterialOverride = new Dictionary<Material, Material>();
 #if UNITY_EDITOR
             if (_IsPrefab())
             {
@@ -707,8 +711,8 @@ namespace DragonBones
                     _armature.animation.Play(animationName, _playTimes);
                 }
             }
-
-
+            else
+                Debug.LogError($"_armature is null, name: {name}");
         }
 
         void Start()
@@ -818,6 +822,15 @@ namespace DragonBones
                     (slot.childArmature.proxy as UnityArmatureComponent).CloseCombineMeshs();
                 }
             }
+        }
+
+        public void SetMaterialOverride(Material material, Material materialOverride)
+        {
+            if (materialOverride != null)
+                _customMaterialOverride[material] = materialOverride;
+            else
+                _customMaterialOverride.Remove(material);
+            _armature.UpdateSlots();
         }
     }
 }

--- a/Unity/src/DragonBones/Scripts/unity/UnitySlot.cs
+++ b/Unity/src/DragonBones/Scripts/unity/UnitySlot.cs
@@ -398,11 +398,17 @@ namespace DragonBones
             {
                 if (this._uiDisplay != null)
                 {
-                    this._uiDisplay.material = (this._textureData as UnityTextureData).GetMaterial(this._blendMode, true);
+                    Material material = (this._textureData as UnityTextureData).GetMaterial(this._blendMode, true);
+                    if (_proxy.CustomMaterialOverride.TryGetValue(material, out Material materialOverride))
+                        material = materialOverride;
+                    this._uiDisplay.material = material;
                 }
                 else
                 {
-                    this._meshRenderer.sharedMaterial = (this._textureData as UnityTextureData).GetMaterial(this._blendMode);
+                    Material material = (this._textureData as UnityTextureData).GetMaterial(this._blendMode);
+                    if (_proxy.CustomMaterialOverride.TryGetValue(material, out Material materialOverride))
+                        material = materialOverride;
+                    this._meshRenderer.sharedMaterial = material;
                 }
 
                 this._meshBuffer.name = this._uiDisplay != null ? this._uiDisplay.material.name : this._meshRenderer.sharedMaterial.name;
@@ -475,7 +481,9 @@ namespace DragonBones
             this._isActive = false;
             if (this._displayIndex >= 0 && this._display != null && currentTextureData != null)
             {
-                var currentTextureAtlas = _proxy.isUGUI ? currentTextureAtlasData.uiTexture : currentTextureAtlasData.texture;
+                Material currentTextureAtlas = _proxy.isUGUI ? currentTextureAtlasData.uiTexture : currentTextureAtlasData.texture;
+                if (_proxy.CustomMaterialOverride.TryGetValue(currentTextureAtlas, out Material materialOverride))
+                    currentTextureAtlas = materialOverride;
                 if (currentTextureAtlas != null)
                 {
                     this._isActive = true;


### PR DESCRIPTION
当前主分支上的UnityArmatureComponent全局共用相同材质球实例，
这导致自定义shader任何属性修改，对相同龙骨资源的实例同时生效。

例如，我添加一个变灰的shader，场景里有10个小怪，其中一个小怪出现灰化的效果
修改材质球参数，10个小怪一起灰化。

(cherry picked from commit 0dba22bdc830c94ba574dcc875578a6a217e4ce2)
允许运行时修改当前UnityArmatureComponent使用的材质球
···
Material fxMaterial = Instantiate(material);
m_ArmatureComponent.SetMaterialOverride(material, fxMaterial);
···
